### PR TITLE
refactor: remove batch UI and tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   <img src="dj-screenshot.png" alt="DJ-CLI Terminal Interface" width="800"/>
 </p>
 
-*DJ-CLI's beautiful terminal interface featuring real-time status updates, batch processing capabilities, and intuitive keyboard controls.*
+*DJ-CLI's beautiful terminal interface featuring real-time status updates and intuitive keyboard controls.*
 
 ---
 
@@ -41,7 +41,6 @@
 - **Lightning-fast downloads** using the battle-tested [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) backend
 - **High-quality audio extraction** with support for 128kbps and 256kbps MP3 output
 - **Smart URL extraction** from messy clipboard text - paste anything, get clean URLs
-- **Batch processing** - queue multiple videos and download them all at once
 - **Async operations** - non-blocking downloads with real-time progress updates
 
 ### 🎨 **Terminal User Interface**
@@ -171,32 +170,9 @@ cargo --version
    - DJ-CLI automatically extracts and cleans the URL from messy clipboard content
 
 3. **Choose Quality & Download**
-   - **Tab** to navigate between input field and download buttons
    - **Enter** for default 128kbps download
    - **Ctrl+1** for quick 128kbps download
    - **Ctrl+2** for quick 256kbps download
-
-### 🎯 Batch Download Mode
-
-1. **Enable Batch Mode**
-   ```
-   Press Ctrl+B to toggle batch mode
-   ```
-
-2. **Add Multiple URLs**
-   ```
-   Paste URL → Press Enter → Repeat for each video
-   ```
-
-3. **Start Batch Download**
-   ```
-   Press Ctrl+D to download all queued videos
-   ```
-
-4. **Monitor Progress**
-   - Real-time progress updates for each download
-   - Success/failure count at completion
-   - Detailed status for each URL in the queue
 
 ### 🎯 Advanced Features
 
@@ -211,10 +187,7 @@ cargo --version
 |----------|----------|
 | **Ctrl+C** | Quit application |
 | **Esc** | Exit application |
-| **Tab** | Switch focus between elements |
-| **Enter** | Download (single mode) / Add URL (batch mode) |
-| **Ctrl+B** | Toggle batch mode |
-| **Ctrl+D** | Start batch download |
+| **Enter** | Download |
 | **Ctrl+1** | Quick 128kbps download |
 | **Ctrl+2** | Quick 256kbps download |
 | **F5** | Clean and extract URL from input |

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
-    Frame,
 };
 // Removed ratatui_input for simplicity
 
@@ -14,9 +14,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     let area = frame.area();
 
     // Create main layout - dynamic constraints based on what needs to be shown
-    let has_download_activity = matches!(app.download_status, DownloadStatus::Downloading) 
+    let has_download_activity = matches!(app.download_status, DownloadStatus::Downloading)
         || !app.download_history.is_empty();
-    
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -24,55 +24,75 @@ pub fn render(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // Spacing
             Constraint::Length(3), // Input box
             Constraint::Length(1), // Spacing
-            Constraint::Length(if app.batch_mode { 6 } else { 0 }), // Batch URLs list (only in batch mode)
             Constraint::Length(4), // Instructions
-            Constraint::Length(2), // Tip
             Constraint::Length(if has_download_activity { 4 } else { 0 }), // Download status (conditional)
-            Constraint::Min(0),    // Remaining space
+            Constraint::Min(0),                                            // Remaining space
         ])
         .split(area);
 
     // Title - Bright neon cyan (classic terminal green alternative)
     let title_text = vec![
-        Line::from(vec![
-            Span::styled(" _____   ______          ___    _       _______ ", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
-        Line::from(vec![
-            Span::styled("(_____) (______)       _(___)_ (_)     (_______)", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
-        Line::from(vec![
-            Span::styled("(_)  (_)     (_)      (_)   (_)(_)        (_)   ", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
-        Line::from(vec![
-            Span::styled("(_)  (_) _   (_)      (_)    _ (_)        (_)   ", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
-        Line::from(vec![
-            Span::styled("(_)__(_)( )__(_)      (_)___(_)(_)____  __(_)__ ", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
-        Line::from(vec![
-            Span::styled("(_____)  (____)         (___)  (______)(_______)", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            " _____   ______          ___    _       _______ ",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "(_____) (______)       _(___)_ (_)     (_______)",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "(_)  (_)     (_)      (_)   (_)(_)        (_)   ",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "(_)  (_) _   (_)      (_)    _ (_)        (_)   ",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "(_)__(_)( )__(_)      (_)___(_)(_)____  __(_)__ ",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "(_____)  (____)         (___)  (______)(_______)",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
     ];
-    
+
     let title = Paragraph::new(title_text)
-        .style(Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD))
+        .style(
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )
         .alignment(ratatui::layout::Alignment::Center);
     frame.render_widget(title, chunks[0]);
 
-    // Input box - Bright yellow when focused/batch mode
-    let input_style = if app.batch_mode || app.is_input_focused() {
-        Style::default().fg(Color::Rgb(255, 255, 0))  // Bright yellow
+    // Input box - Bright yellow when focused
+    let input_style = if app.is_input_focused() {
+        Style::default().fg(Color::Rgb(255, 255, 0)) // Bright yellow
     } else {
-        Style::default().fg(Color::Rgb(255, 255, 255))  // Bright white
+        Style::default().fg(Color::Rgb(255, 255, 255)) // Bright white
     };
 
     let input_block = Block::default()
         .borders(Borders::ALL)
-        .title(if app.batch_mode { "YouTube URL" } else { "YouTube URL" })
-        .border_style(if app.batch_mode || app.is_input_focused() {
-            Style::default().fg(Color::Rgb(255, 255, 0))  // Bright yellow border
+        .title("YouTube URL")
+        .border_style(if app.is_input_focused() {
+            Style::default().fg(Color::Rgb(255, 255, 0)) // Bright yellow border
         } else {
-            Style::default().fg(Color::Rgb(128, 128, 128))  // Gray
+            Style::default().fg(Color::Rgb(128, 128, 128)) // Gray
         });
 
     let input_widget = Paragraph::new(app.input_value())
@@ -80,113 +100,60 @@ pub fn render(frame: &mut Frame, app: &App) {
         .block(input_block);
     frame.render_widget(input_widget, chunks[2]);
 
-    // Batch URLs list (only show in batch mode)
-    if app.batch_mode && chunks.len() > 4 {
-        let batch_text: Vec<Line> = if app.batch_urls.is_empty() {
-            vec![Line::from(vec![
-                Span::styled("No URLs added yet. Press Enter to add.", Style::default().fg(Color::Rgb(128, 128, 128)))  // Gray
-            ])]
-        } else {
-            let mut lines = vec![Line::from(vec![
-                Span::styled(format!("Queue ({}):", app.batch_urls.len()), Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD))  // Bright cyan
-            ])];
-            
-            for (i, url) in app.batch_urls.iter().enumerate() {
-                let display_url = if url.len() > 30 {
-                    format!("{}...", &url[..27])
-                } else {
-                    url.clone()
-                };
-                lines.push(Line::from(vec![
-                    Span::styled(format!("{}. ", i + 1), Style::default().fg(Color::Rgb(255, 255, 0))),  // Bright yellow numbers
-                    Span::styled(display_url, Style::default().fg(Color::Rgb(255, 255, 255)))  // Bright white text
-                ]));
-            }
-            lines
-        };
-
-        let batch_widget = Paragraph::new(batch_text)
-            .style(Style::default().fg(Color::Rgb(255, 255, 255)))  // Bright white
-            .block(Block::default().borders(Borders::ALL).title("Batch Queue"));
-        frame.render_widget(batch_widget, chunks[4]);
-    }
-
     // Instructions section
-    let instructions_chunk = if app.batch_mode && chunks.len() > 5 { chunks[5] } else if chunks.len() > 4 { chunks[5] } else { chunks[chunks.len() - 2] };
-    
-    let instructions_text = if app.batch_mode {
-        vec![
-            Line::from(vec![
-                Span::styled("📋 BATCH MODE:", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD))  // Bright cyan
-            ]),
-            Line::from(vec![
-                Span::styled("1. ", Style::default().fg(Color::Rgb(255, 255, 0))),  // Bright yellow
-                Span::raw("Paste URL, press "),
-                Span::styled("Enter", Style::default().fg(Color::Rgb(0, 255, 0)).add_modifier(Modifier::BOLD)),  // Bright green
-                Span::raw(" to add"),
-            ]),
-            Line::from(vec![
-                Span::styled("2. ", Style::default().fg(Color::Rgb(255, 255, 0))),  // Bright yellow
-                Span::raw("Press "),
-                Span::styled("Ctrl+D", Style::default().fg(Color::Rgb(0, 255, 0)).add_modifier(Modifier::BOLD)),  // Bright green
-                Span::raw(" to start batch download"),
-            ]),
-        ]
-    } else {
-        vec![
-            Line::from(vec![
-                Span::styled("📋 SINGLE MODE:", Style::default().fg(Color::Rgb(0, 255, 255)).add_modifier(Modifier::BOLD))  // Bright cyan
-            ]),
-            Line::from(vec![
-                Span::styled("1. ", Style::default().fg(Color::Rgb(255, 255, 0))),  // Bright yellow
-                Span::raw("Paste URL, press "),
-                Span::styled("Enter", Style::default().fg(Color::Rgb(0, 255, 0)).add_modifier(Modifier::BOLD)),  // Bright green
-                Span::raw(" to download"),
-            ]),
-            Line::from(vec![
-                Span::styled("2. ", Style::default().fg(Color::Rgb(255, 255, 0))),  // Bright yellow
-                Span::raw("Press "),
-                Span::styled("Ctrl+B", Style::default().fg(Color::Rgb(0, 255, 0)).add_modifier(Modifier::BOLD)),  // Bright green
-                Span::raw(" for batch mode"),
-            ]),
-        ]
-    };
-
-    let instructions = Paragraph::new(instructions_text)
-        .style(Style::default().fg(Color::Rgb(255, 255, 255)))  // Bright white
-        .block(Block::default().borders(Borders::ALL).title("How to Use"));
-    frame.render_widget(instructions, instructions_chunk);
-
-    // Just show the tip at the bottom - much cleaner
-    let tip_text = vec![
+    let instructions_text = vec![
+        Line::from(vec![Span::styled(
+            "📋 HOW TO USE:",
+            Style::default()
+                .fg(Color::Rgb(0, 255, 255))
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
-            Span::styled("💡 Tip:", Style::default().fg(Color::Rgb(0, 255, 255))),  // Bright cyan
-            Span::raw(" Paste messy text - URLs auto-extracted, input sanitized & limited"),
+            Span::styled("1. ", Style::default().fg(Color::Rgb(255, 255, 0))), // Bright yellow
+            Span::raw("Paste URL, press "),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(Color::Rgb(0, 255, 0))
+                    .add_modifier(Modifier::BOLD),
+            ), // Bright green
+            Span::raw(" to download"),
+        ]),
+        Line::from(vec![
+            Span::styled("2. ", Style::default().fg(Color::Rgb(255, 255, 0))), // Bright yellow
+            Span::raw("Press "),
+            Span::styled(
+                "F5",
+                Style::default()
+                    .fg(Color::Rgb(0, 255, 0))
+                    .add_modifier(Modifier::BOLD),
+            ), // Bright green
+            Span::raw(" to clean pasted text"),
         ]),
     ];
 
-    let tip = Paragraph::new(tip_text)
-        .style(Style::default().fg(Color::Rgb(200, 200, 200)))  // Light gray
-        .block(Block::default());
-    
-    let tip_chunk = if app.batch_mode && chunks.len() > 6 { chunks[6] } else if chunks.len() > 5 { chunks[6] } else { chunks[chunks.len() - 3] };
-    frame.render_widget(tip, tip_chunk);
-    
+    let instructions = Paragraph::new(instructions_text)
+        .style(Style::default().fg(Color::Rgb(255, 255, 255))) // Bright white
+        .block(Block::default().borders(Borders::ALL).title("How to Use"));
+    frame.render_widget(instructions, chunks[4]);
+
     // Download status and history (only when there's activity)
     if has_download_activity {
         let mut status_lines = Vec::new();
-        
+
         // Show current download status if downloading
-        match &app.download_status {
-            DownloadStatus::Downloading => {
-                status_lines.push(Line::from(vec![
-                    Span::styled("🎵 ", Style::default().fg(Color::Rgb(255, 255, 0))),
-                    Span::styled("Downloading...", Style::default().fg(Color::Rgb(255, 255, 0)).add_modifier(Modifier::BOLD)),
-                ]));
-            }
-            _ => {}
+        if let DownloadStatus::Downloading = &app.download_status {
+            status_lines.push(Line::from(vec![
+                Span::styled("🎵 ", Style::default().fg(Color::Rgb(255, 255, 0))),
+                Span::styled(
+                    "Downloading...",
+                    Style::default()
+                        .fg(Color::Rgb(255, 255, 0))
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
         }
-        
+
         // Show recent downloads (last 2 to keep it compact)
         for download in app.download_history.iter().rev().take(2) {
             // Wrap long filenames - truncate at 50 chars and add ...
@@ -195,21 +162,19 @@ pub fn render(frame: &mut Frame, app: &App) {
             } else {
                 download.clone()
             };
-            
+
             status_lines.push(Line::from(vec![
                 Span::styled("✅ ", Style::default().fg(Color::Rgb(0, 255, 0))),
                 Span::styled(display_name, Style::default().fg(Color::Rgb(0, 255, 0))),
             ]));
         }
-        
+
         let status_widget = Paragraph::new(status_lines)
             .style(Style::default().fg(Color::Rgb(255, 255, 255)))
             .block(Block::default().borders(Borders::ALL).title("Downloads"))
             .wrap(Wrap { trim: true });
-        
-        let status_chunk = chunks[chunks.len() - 2];
+
+        let status_chunk = chunks[5];
         frame.render_widget(status_widget, status_chunk);
     }
 }
-
-


### PR DESCRIPTION
## Summary
- drop batch download mode and related state
- simplify TUI and instructions for single downloads
- clean README to match UI and shortcuts

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b622ef228832bb77028e2f4241c72